### PR TITLE
Improve repository URL parsing (fix #6)

### DIFF
--- a/anymatrix.m
+++ b/anymatrix.m
@@ -580,7 +580,8 @@ end
         group_folder = strcat(root_path, '/', group_ID, '/');
         % If the group does not exist locally, create folders and clone it.
         if ~isfolder(group_folder)
-            if startsWith(repo_ID, 'http')
+            if count(repo_ID, '/') > 1 || ...
+	        contains(repo_ID, ':') || contains(repo_ID, '@')
                 status = system(strcat( ...
                     "git clone ", """", repo_ID, """ ", ...
                     """", group_folder, 'private"'), '-echo');


### PR DESCRIPTION
This should fix #6 and also allow users to access repository using a variety of protocols, not just `http`/`https`.